### PR TITLE
[FEATURE] Include class name inside factory not found error

### DIFF
--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -140,7 +140,7 @@ class FactoryBuilder
     protected function makeInstance(array $attributes = [])
     {
         if (!isset($this->definitions[$this->class][$this->name])) {
-            throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}].");
+            throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}] [{$this->class}].");
         }
 
         $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);


### PR DESCRIPTION
Mimics Laravel's original way of doing it and helps find what needs to be implemented.

### Changes proposed in this pull request:
- Will print class name after factory name when no factory is found.

This:
```
Unable to locate factory with name [default].
```
Becomes this:
```
Unable to locate factory with name [default] [App\User].
```